### PR TITLE
fix: remove duplicate back, front and refresh button event listeners

### DIFF
--- a/core/src/sidebar/sidebar.js
+++ b/core/src/sidebar/sidebar.js
@@ -76,18 +76,6 @@ document.getElementById("hide").addEventListener("click", function() {
   handleBrowserControl("hide");
 });
 
-document.getElementById("back").addEventListener("click", function() {
-  handleBrowserControl("back");
-});
-
-document.getElementById("front").addEventListener("click", function() {
-  handleBrowserControl("front");
-});
-
-document.getElementById("refresh").addEventListener("click", function() {
-  handleBrowserControl("refresh");
-});
-
 document.addEventListener("click", (event) => {
   if (event.target.classList.contains("browser-control-button")) {
     handleButtonClick(event);


### PR DESCRIPTION
i've noticed that when i click on the back button, sometimes it goes back twice.

this PR removes duplicate event listeners